### PR TITLE
Memoize examples and user-code in the URL

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@uiw/react-textarea-code-editor": "^3.1.0",
         "decamelize": "^6.0.0",
+        "lz-string": "^1.5.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-icons": "^5.4.0",
@@ -5260,6 +5261,15 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "license": "MIT",
+      "bin": {
+        "lz-string": "bin/bin.js"
       }
     },
     "node_modules/make-dir": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "@uiw/react-textarea-code-editor": "^3.1.0",
     "decamelize": "^6.0.0",
+    "lz-string": "^1.5.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-icons": "^5.4.0",

--- a/src/examples/empty.js
+++ b/src/examples/empty.js
@@ -1,0 +1,6 @@
+export const name = 'Empty';
+export const content = `<?php
+
+declare(strict_types=1);
+
+`;

--- a/src/examples/index.js
+++ b/src/examples/index.js
@@ -1,11 +1,13 @@
 import * as security from "./security.js";
 import * as calculator from "./calculator.js";
 import * as undefined from "./undefined.js";
+import * as empty from "./empty.js";
 
 const examples = {
   security,
   calculator,
   undefined,
+  empty,
 };
 
 export default examples;


### PR DESCRIPTION
Adds the selected example and user-code in the URL so that a playground link can easily be shared.

It uses the same system as https://www.typescriptlang.org/play/

![Screenshot 2025-01-31 at 08 38 01](https://github.com/user-attachments/assets/1695799d-b625-4cf2-9682-bf2ca6c31dde)
![Screenshot 2025-01-31 at 08 38 12](https://github.com/user-attachments/assets/9c2987eb-811b-40ef-a879-00fde1de96a4)
